### PR TITLE
Fix deep XML entity nesting, add README, bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,87 @@
-# Unraid NCT6687d Driver plugin
+# Unraid NCT6687d Driver Plugin
 
-This is the repository for the Unraid NCT6687d Driver plugin based on: https://github.com/Fred78290/nct6687d
+NCT6687D kernel module for Unraid, enabling hardware monitoring and fan control on motherboards with the Nuvoton NCT6687-R chipset (common on MSI B550/B650/X670/Z690/Z790 and similar boards).
+
+Based on: https://github.com/Fred78290/nct6687d
+
+---
+
+## Installation
+
+### Via Unraid Web UI (recommended)
+1. Open **Apps** tab
+2. Click **Install Plugin** (top-right)
+3. Paste this URL:
+   ```
+   https://raw.githubusercontent.com/ich777/unraid-nct6687-driver/master/nct6687-driver.plg
+   ```
+4. Click **Install**
+
+### Via command line
+```sh
+wget -O /boot/config/plugins/nct6687-driver.plg \
+  https://raw.githubusercontent.com/ich777/unraid-nct6687-driver/master/nct6687-driver.plg
+/usr/local/emhttp/plugins/plugin/install.plg /boot/config/plugins/nct6687-driver.plg
+```
+
+## What it does
+
+On every boot, the plugin:
+1. **Blacklists** the stock `nct6683` kernel module (which conflicts with `nct6687`)
+2. **Checks** the running kernel version (`uname -r`)
+3. **Downloads** the matching `.txz` driver package from the GitHub releases
+4. **Installs** the package with `installpkg` + `depmod -a`
+5. **Loads** the `nct6687` module
+6. Pre-downloads the driver ahead of Unraid OS updates via the **Plugin Update Helper**
+
+## Fan Control
+
+After install, writable PWM controls are available:
+
+```sh
+# List NCT6687 sysfs path
+for d in /sys/class/hwmon/*; do echo "$d: $(cat $d/name 2>/dev/null)"; done | grep nct6687
+```
+
+### Manual fan control
+```sh
+# Set fan to manual mode
+echo 1 > /sys/class/hwmon/hwmon*/pwm1_enable
+# Set fan to 50% speed
+echo 128 > /sys/class/hwmon/hwmon*/pwm1
+# Return to auto
+echo 99 > /sys/class/hwmon/hwmon*/pwm1_enable
+```
+
+### Automatic fan control
+Install **Dynamix System Autofan** from the Apps tab to configure temperature-based fan curves.
+
+## Module Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| force | bool | false | Enable support for unknown vendors |
+| manual | bool | false | Manual voltage input/label configuration |
+| msi_fan_brute_force | bool | false | [BETA] Write PWM to all 7 curve points for MSI boards |
+
+See upstream docs: https://github.com/Fred78290/nct6687d
+
+## Troubleshooting
+
+**No PWM controls visible?**
+The `nct6683` module may have loaded instead. The plugin auto-blacklists it, but if you see read-only `pwm` files, verify the active module:
+```sh
+cat /sys/class/hwmon/hwmon*/name
+```
+If it says `nct6683`, run:
+```sh
+rmmod nct6683
+modprobe nct6687
+```
+
+**After Unraid OS update:**
+The Plugin Update Helper pre-downloads the matching driver before the update. If it doesn't load after reboot, reinstall or manually download the matching release from GitHub.
+
+## Support
 
 Support Thread: https://forums.unraid.net/topic/92865-support-ich777-nvidiadvbzfsiscsimft-kernel-helperbuilder-docker/

--- a/nct6687-driver.plg
+++ b/nct6687-driver.plg
@@ -3,7 +3,6 @@
   <!ENTITY name      "nct6687-driver">
   <!ENTITY author    "ich777">
   <!ENTITY version   "2026.06.21">
-  <!ENTITY gitURL    "https://github.com/ich777/unraid-nct6687-driver/raw/master">
   <!ENTITY pluginURL "https://raw.githubusercontent.com/ich777/unraid-nct6687-driver/master/nct6687-driver.plg">
   <!ENTITY plugin    "/boot/config/plugins/nct6687-driver">
   <!ENTITY emhttp    "/usr/local/emhttp/plugins/nct6687-driver">

--- a/nct6687-driver.plg
+++ b/nct6687-driver.plg
@@ -14,6 +14,10 @@
 
 <CHANGES>
 
+###2026.06.21
+- Flatten XML entities to fix install failure on some Unraid systems
+- Add Dynamix System Autofan example to plugin README
+
 ###2025.05.12
 - Prevent installation from NCT6683 module on boot
 
@@ -58,8 +62,24 @@ rm -f $(ls /boot/config/plugins/&name;/&name;*.txz 2>/dev/null|grep -v '&version
 <INLINE>
 **Nuvoton NCT6687 Driver**
 
-This package contains the NCT6687 Drivers and installs them for using it with the Dynamix System Temperature Plugin.  
-  
+This plugin installs the NCT6687D kernel module for Unraid, enabling hardware monitoring and fan control on motherboards with the Nuvoton NCT6687-R chipset (common on MSI B550/B650/X670/Z690/Z790 and similar boards).
+
+**Supported features:**
+- Temperature monitoring (CPU, system, PCH, VRM)
+- Fan speed monitoring (CPU, pump, system fans)
+- Fan speed control (PWM) via sysfs or Dynamix System Autofan
+- Voltages monitoring
+
+**Fan Control:**
+After install, the nct6687 module exposes writable PWM controls:
+  /sys/class/hwmon/hwmon*/pwm[1-8]
+  /sys/class/hwmon/hwmon*/pwm[1-8]_enable
+
+Install the **Dynamix System Autofan** plugin from Apps to configure automatic fan curves.
+
+**Automatic updates:**
+This plugin includes the Plugin Update Helper, which pre-downloads the matching driver package when Unraid OS is updated, ensuring seamless compatibility.
+
 Source: https://github.com/Fred78290/nct6687d
 </INLINE>
 </FILE>

--- a/nct6687-driver.plg
+++ b/nct6687-driver.plg
@@ -61,7 +61,7 @@ rm -f $(ls /boot/config/plugins/&name;/&name;*.txz 2>/dev/null|grep -v '&version
 <INLINE>
 **Nuvoton NCT6687 Driver**
 
-NCT6687D kernel module for hardware monitoring and fan control on MSI and similar boards. Install **Dynamix System Autofan** from Apps for automatic fan curves.
+NCT6687D kernel module for hardware monitoring and fan control on MSI and similar boards. Install **FanCtrl Plus** or **Dynamix System Autofan** from Apps for automatic fan curves.
 
 Source: https://github.com/Fred78290/nct6687d
 </INLINE>

--- a/nct6687-driver.plg
+++ b/nct6687-driver.plg
@@ -64,6 +64,7 @@ rm -f $(ls /boot/config/plugins/&name;/&name;*.txz 2>/dev/null|grep -v '&version
 NCT6687D kernel module for hardware monitoring and fan control on MSI and similar boards. Install **FanCtrl Plus** or **Dynamix System Autofan** from Apps for automatic fan curves.
 
 Source: https://github.com/Fred78290/nct6687d
+Plugin: https://github.com/ich777/unraid-nct6687-driver
 </INLINE>
 </FILE>
 

--- a/nct6687-driver.plg
+++ b/nct6687-driver.plg
@@ -61,23 +61,7 @@ rm -f $(ls /boot/config/plugins/&name;/&name;*.txz 2>/dev/null|grep -v '&version
 <INLINE>
 **Nuvoton NCT6687 Driver**
 
-This plugin installs the NCT6687D kernel module for Unraid, enabling hardware monitoring and fan control on motherboards with the Nuvoton NCT6687-R chipset (common on MSI B550/B650/X670/Z690/Z790 and similar boards).
-
-**Supported features:**
-- Temperature monitoring (CPU, system, PCH, VRM)
-- Fan speed monitoring (CPU, pump, system fans)
-- Fan speed control (PWM) via sysfs or Dynamix System Autofan
-- Voltages monitoring
-
-**Fan Control:**
-After install, the nct6687 module exposes writable PWM controls:
-  /sys/class/hwmon/hwmon*/pwm[1-8]
-  /sys/class/hwmon/hwmon*/pwm[1-8]_enable
-
-Install the **Dynamix System Autofan** plugin from Apps to configure automatic fan curves.
-
-**Automatic updates:**
-This plugin includes the Plugin Update Helper, which pre-downloads the matching driver package when Unraid OS is updated, ensuring seamless compatibility.
+NCT6687D kernel module for hardware monitoring and fan control on MSI and similar boards. Install **Dynamix System Autofan** from Apps for automatic fan curves.
 
 Source: https://github.com/Fred78290/nct6687d
 </INLINE>

--- a/nct6687-driver.plg
+++ b/nct6687-driver.plg
@@ -3,11 +3,11 @@
   <!ENTITY name      "nct6687-driver">
   <!ENTITY author    "ich777">
   <!ENTITY version   "2025.05.12">
-  <!ENTITY gitURL    "https://github.com/&author;/unraid-&name;/raw/master">
-  <!ENTITY pluginURL "&gitURL;/&name;.plg">
-  <!ENTITY plugin    "/boot/config/plugins/&name;">
-  <!ENTITY emhttp    "/usr/local/emhttp/plugins/&name;">
-  <!ENTITY packages  "/boot/config/plugins/&name;/packages">
+  <!ENTITY gitURL    "https://github.com/ich777/unraid-nct6687-driver/raw/master">
+  <!ENTITY pluginURL "https://raw.githubusercontent.com/ich777/unraid-nct6687-driver/master/nct6687-driver.plg">
+  <!ENTITY plugin    "/boot/config/plugins/nct6687-driver">
+  <!ENTITY emhttp    "/usr/local/emhttp/plugins/nct6687-driver">
+  <!ENTITY packages  "/boot/config/plugins/nct6687-driver/packages">
 ]>
 
 <PLUGIN  name="&name;" author="&author;" version="&version;" pluginURL="&pluginURL;" min="6.9.0">

--- a/nct6687-driver.plg
+++ b/nct6687-driver.plg
@@ -2,7 +2,7 @@
 <!DOCTYPE PLUGIN [
   <!ENTITY name      "nct6687-driver">
   <!ENTITY author    "ich777">
-  <!ENTITY version   "2025.05.12">
+  <!ENTITY version   "2026.06.21">
   <!ENTITY gitURL    "https://github.com/ich777/unraid-nct6687-driver/raw/master">
   <!ENTITY pluginURL "https://raw.githubusercontent.com/ich777/unraid-nct6687-driver/master/nct6687-driver.plg">
   <!ENTITY plugin    "/boot/config/plugins/nct6687-driver">


### PR DESCRIPTION
## Problem

The plugin file uses deeply nested XML entities (\&pluginURL;\ → \&gitURL;\ → \&author;\ + \&name;\), which hits PHP libxml's \maxEntityExpansionLimit\ on some Unraid installations, causing a parse error.

## Fix

Flattened all entity definitions so no entity references another entity. Removed unused \&gitURL;\ entity.

## Additional

- Expanded repo README.md with install/usage/troubleshooting docs
- Notes FanCtrl Plus + Dynamix System Autofan for automatic fan curves
- Version bumped to \2026.06.21\
- Changelog entry added